### PR TITLE
Removes viewport references in filtering system

### DIFF
--- a/src/CompositeFilter.js
+++ b/src/CompositeFilter.js
@@ -20,7 +20,7 @@ export class CompositeFilter extends Filter
 
     /**
      * Keep the given filter as a nested filter. This will bind the padding
-     * & viewport properties of this filter to the nested filter.
+     * & other properties of this filter to the nested filter.
      *
      * @param {PIXI.Filter} filter
      * @param {boolean}[noBind=false] - prevents uniform binding from parent to child
@@ -30,7 +30,6 @@ export class CompositeFilter extends Filter
     keep(filter, noBind = false)
     {
         filter.parentFilter = this;
-        filter.viewport = this.viewport;
         filter.uniforms.binding = noBind ? null : this.uniformGroup;
 
         this.nestedFilters.push(filter);
@@ -52,20 +51,6 @@ export class CompositeFilter extends Filter
             filter.uniforms.binding = null;
             filter.parentFilter = null;
             this.nestedFilters.splice(index, 1);
-        }
-    }
-
-    get viewport()
-    {
-        return this._viewport;
-    }
-    set viewport(value)
-    {
-        this._viewport = value;
-
-        for (const filter of this.nestedFilters)
-        {
-            filter.viewport = value;
         }
     }
 }

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -17,18 +17,11 @@ export class Filter extends BaseFilter
         super(vertex, fragment, uniforms);
 
         this.additivePadding = false;
-
         this.nestedFilters = [];
-
         this.parentFilter = null;// are you just a filter-pass for another fitler?
-
         this.padding = undefined;
 
-        /**
-         * Render options that work when applying this filter.
-         *
-         * @member {PIXI.RenderOptions}
-         */
+        /** @todo This might be eliminated from the code fully. */
         this.renderOptions = {};
     }
 
@@ -39,9 +32,7 @@ export class Filter extends BaseFilter
      * @abstract
      *
      * Create a <code>defaultPadding</code> property if your filter has an instrinsic need
-     * for one. The padding can be overridden by the client. The default padding
-     * should return the padding needed when viewport scale is 1 (it should not
-     * consider viewport in its calculation)
+     * for one. The padding can be overridden by the client.
      */
 
     /**
@@ -57,7 +48,7 @@ export class Filter extends BaseFilter
 
     get padding()
     {
-        let normalPadding;// padding when viewport scale is 1
+        let normalPadding;
 
         if (this._paddingOverride !== undefined)
         {
@@ -72,7 +63,7 @@ export class Filter extends BaseFilter
             normalPadding = 0;
         }
 
-        let padding = normalPadding * this.viewportScale;
+        let padding = normalPadding;
 
         for (const filter of this.nestedFilters)
         {
@@ -155,10 +146,17 @@ export class Filter extends BaseFilter
         return this._renderable;
     }
 
+    /** @deprecated */
+    get viewport()
+    {
+        throw new Error('viewport is deprecated');
+    }
+
+    /** @deprcated */
     get viewportScale()
     {
         // TRANSITION: Projection-matrix viewport
-        return this.viewport ? Math.max(this.viewport.scale.x, this.viewport.scale.y) : 1;
+        throw new Error('viewportScale should not be used now.');
     }
 
     apply(filterManager, input, output, clear, state, renderOptions)

--- a/src/FilterPipe.js
+++ b/src/FilterPipe.js
@@ -402,7 +402,7 @@ export class FilterPipe
         }
         else
         {
-            bridgeTexture = this.filterManager.getFilterTexture(this.input);
+            bridgeTexture = this.filterManager.getFilterTexture(this.input, this.state.resolution);
         }
 
         bridgeTexture.filterFrame = frame;// this will be set when used!

--- a/src/FilterScope.js
+++ b/src/FilterScope.js
@@ -1,11 +1,5 @@
 import { Point, Rectangle } from 'pixi.js';
 
-const defaultScale = new Point(1, 1);
-
-const defaultViewport = {
-    scale: defaultScale,
-};
-
 /**
  * Stateful object for handling filters of a specific display object.
  *
@@ -128,13 +122,6 @@ export class FilterScope
         this.currentIndex = 0;
 
         /**
-         * Viewport object for reading scal.
-         * @member {PIXI.Viewport}
-         * @readonly
-         */
-        this.viewport = defaultViewport;
-
-        /**
          * This is copy of the renderer's state before filtering.
          *
          * @member {object}
@@ -211,8 +198,8 @@ export class FilterScope
 
     normalize(ivec, ovec)
     {
-        ovec.x = ivec.x * this.viewport.scale.x / this.texturePixels.x;
-        ovec.y = ivec.y * this.viewport.scale.y / this.texturePixels.y;
+        ovec.x = ivec.x * this.resolution / this.texturePixels.x;
+        ovec.y = ivec.y * this.resolution / this.texturePixels.y;
     }
 
     /**
@@ -225,7 +212,6 @@ export class FilterScope
         this.filters = null;
         this.renderTexture = null;
         this.resolution = 1;
-        this.viewport = defaultViewport;
         this._nakedTargetBounds = null;
         this._nakedSourceFrame = null;
 

--- a/src/FilterSystem.js
+++ b/src/FilterSystem.js
@@ -79,6 +79,12 @@ export class FilterSystem extends systems.FilterSystem
         {
             state.resolution = this.renderer.renderTexture.current.baseTexture.resolution;
         }
+        else
+        {
+            const { destinationFrame, sourceFrame } = this.renderer.projection;
+
+            state.resolution = nextPow2(Math.max(Math.min(destinationFrame.width / sourceFrame.width, 16), 1));
+        }
 
         state.rendererSnapshot.sourceFrame.copyFrom(renderer.renderTexture.sourceFrame);
         state.rendererSnapshot.destinationFrame.copyFrom(renderer.renderTexture.destinationFrame);
@@ -317,19 +323,11 @@ export class FilterSystem extends systems.FilterSystem
         {
             const filter =  filters[i];
 
-            filter.resolution = state.resolution;
-
             autoFit = autoFit && filter.autoFit;
             legacy = legacy || filter.legacy;
-
-            //    if (!filter.additivePadding)
-            //    {
             padding = Math.max(padding, filter.padding);
-            //    }
-            //    else
-            //    {
-            //        padding += filter.padding;
-            //    }
+
+            filter.resolution = state.resolution;
         }
 
         state.legacy = legacy;
@@ -433,9 +431,7 @@ export class FilterSystem extends systems.FilterSystem
     filterPassRenderTextureFor(state)
     {
         let width = 0;
-
         let height = 0;
-
         let defaultIncluded = false;
 
         for (let i = 0; i < state.filters.length; i++)

--- a/src/FilterSystem.js
+++ b/src/FilterSystem.js
@@ -64,12 +64,6 @@ export class FilterSystem extends systems.FilterSystem
         }
 
         filterStack.push(state);
-
-        if (options.viewport)
-        {
-            state.viewport = options.viewport;
-        }
-
         this.measure(state);
 
         if (options.padding)
@@ -81,9 +75,9 @@ export class FilterSystem extends systems.FilterSystem
         {
             state.resolution = options.resolution;
         }
-        else if (options.viewport)
+        else if (this.renderer.renderTexture.current)
         {
-        //    state.resolution = nextPow2(options.viewport.scale.x);
+            state.resolution = this.renderer.renderTexture.current.baseTexture.resolution;
         }
 
         state.rendererSnapshot.sourceFrame.copyFrom(renderer.renderTexture.sourceFrame);
@@ -267,7 +261,7 @@ export class FilterSystem extends systems.FilterSystem
 
             gl.enable(gl.SCISSOR_TEST);
             gl.scissor(x, y, width, height);
-            renderer.renderTexture.clear([Math.random(), Math.random(), Math.random(), 1]);
+            renderer.renderTexture.clear();
             renderer.scissor.pop();
         }
         else if (clear)
@@ -316,18 +310,13 @@ export class FilterSystem extends systems.FilterSystem
         const resolution = filters[0].resolution;
 
         let autoFit = filters[0].autoFit;
-
         let legacy = filters[0].legacy;
-
-        filters[0].viewport = state.viewport;
-
         let padding = filters[0].padding;
 
         for (let i = 1; i < filters.length; i++)
         {
             const filter =  filters[i];
 
-            filter.viewport = state.viewport;
             filter.resolution = state.resolution;
 
             autoFit = autoFit && filter.autoFit;
@@ -374,7 +363,6 @@ export class FilterSystem extends systems.FilterSystem
         {
             const filter = filters[i];
 
-            filter.viewport = { scale: state.target.scale };
             filter.measure(targetFrame, filterPassFrame.clone(), padding);
             const filterInput = filters[i].frame.fit(targetFrame);
 
@@ -432,11 +420,6 @@ export class FilterSystem extends systems.FilterSystem
     premeasure(target, filters, options = target.filterOptions)
     {
         const pipe = this._newPipe(target, filters);
-
-        if (options)
-        {
-            pipe.viewport = options.viewport;
-        }
 
         this.measure(pipe);
 
@@ -666,5 +649,4 @@ FilterSystem.geometryPool = [];
  * @namespace PIXI
  * @property {number} padding - atleast this much padding will be provided
  * @property {number} resolution - override resolution for filters
- * @property {PIXI.Viewport} viewport - viewport provided to filters
  */


### PR DESCRIPTION
This is in parallel with the transition to using a projection-matrix in our viewport.